### PR TITLE
Add cached DMA buffer option with cache maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ output/
 # Allow for gitignore files and the LICENSE
 !.gitignore
 !/LICENSE
+
+!/CODE_OVERVIEW.md

--- a/CODE_OVERVIEW.md
+++ b/CODE_OVERVIEW.md
@@ -1,0 +1,17 @@
+# Code Overview
+
+This repository contains a Linux kernel driver and userspace library that expose high-bandwidth DMA access to Xilinx AXI DMA and VDMA IP blocks. The sections below summarize the main components and how they interact.
+
+## Kernel driver (driver/)
+- **Module entry and platform binding (`driver/axi_dma.c`)**: Registers a platform driver for device-tree nodes compatible with `xlnx,axidma-chrdev`, allocates a device structure, initializes DMA handling, and sets up the character device interface. Probe and remove hooks ensure DMA and character device resources are initialized and cleaned up with the platform device lifecycle.
+- **Module parameters**: The `cached_buffers` boolean enables cached, non-coherent CMA allocations for `mmap` requests to accelerate CPU-side copies (for example, moving DMA data to SSDs). When enabled, the driver performs cache maintenance before and after transfers so applications can use the buffers without manual flushing.
+- **Driver-wide definitions (`driver/axidma.h`)**: Defines the `axidma_device` structure that tracks device metadata (character device info, channel counts, callback data, and DMA buffer lists) and declares helper functions for character device setup, DMA operations, and device-tree parsing.
+- **Character device and buffer management (`driver/axidma_chrdev.c`)**: Implements the `/dev/axidma` interface, including tracking DMA buffer allocations, converting user virtual addresses to DMA bus addresses, and importing shared DMA buffers from other kernel drivers. Allocation metadata is kept in linked lists so transfer preparation code can validate requests.
+- **DMA operation helpers (`driver/axidma_dma.c`)**: Prepares scatter-gather tables from registered buffers, converts AXI DMA directions to DMA engine enums, and sets up completion callbacks. Transfers carry completion or signal-delivery metadata so synchronous callers can wait and asynchronous callers can receive POSIX real-time signals when DMA finishes.
+
+## Userspace library (library/libaxidma.c)
+- Maintains a single `axidma_dev` instance with channel metadata, file descriptor, and callback registrations. On initialization, the library probes the driver for available channels via IOCTLs, categorizes them by direction and type, and caches their IDs for future transfers.
+- Provides the callback trampoline that delivers completion signals back to the caller, mapping kernel-provided channel indices into per-channel callbacks supplied by the application.
+
+## Example applications (examples/)
+- Sample programs demonstrate synchronous and asynchronous transfer flows and utility routines for buffer handling. They compile against the exported headers in `include/` and the shared library built into `outputs/`.

--- a/driver/axi_dma.c
+++ b/driver/axi_dma.c
@@ -31,6 +31,10 @@ module_param(chrdev_name, charp, S_IRUGO);
 static int minor_num = MINOR_NUMBER;
 module_param(minor_num, int, S_IRUGO);
 
+// Enable cached, non-coherent DMA buffers to accelerate CPU-side copies.
+static bool cached_buffers;
+module_param(cached_buffers, bool, 0444);
+
 /*----------------------------------------------------------------------------
  * Platform Device Functions
  *----------------------------------------------------------------------------*/
@@ -58,6 +62,7 @@ static int axidma_probe(struct platform_device *pdev)
     axidma_dev->chrdev_name = chrdev_name;
     axidma_dev->minor_num = minor_num;
     axidma_dev->num_devices = NUM_DEVICES;
+    axidma_dev->cached_buffers = cached_buffers;
 
     // Initialize the character device for the module.
     rc = axidma_chrdev_init(axidma_dev);

--- a/driver/axidma.h
+++ b/driver/axidma.h
@@ -66,6 +66,10 @@ struct axidma_device {
     struct axidma_chan *channels;   // All available channels
     struct list_head dmabuf_list;   // List of allocated DMA buffers
     struct list_head external_dmabufs;  // Buffers allocated in other drivers
+
+    /* When true, user buffers are allocated as cached, non-coherent mappings
+     * that require explicit cache maintenance before/after DMA. */
+    bool cached_buffers;
 };
 
 /*----------------------------------------------------------------------------

--- a/driver/axidma_chrdev.c
+++ b/driver/axidma_chrdev.c
@@ -22,6 +22,7 @@
 #include <linux/slab.h>         // Kernel allocation functions
 #include <linux/errno.h>        // Linux error codes
 #include <linux/of_device.h>    // Device tree device related functions
+#include <linux/dma-mapping.h>  // DMA mapping helpers
 
 #include <linux/dma-buf.h>      // DMA shared buffers interface
 #include <linux/scatterlist.h>  // Scatter-gather table definitions
@@ -43,6 +44,7 @@ struct axidma_dma_allocation {
     void *user_addr;            // User virtual address of the buffer
     void *kern_addr;            // Kernel virtual address of the buffer
     dma_addr_t dma_addr;        // DMA bus address of the buffer
+    bool cached_mapping;        // Indicates cached, non-coherent mapping
     struct list_head list;      // List node pointers for allocation list
 };
 
@@ -211,8 +213,13 @@ static void axidma_vma_close(struct vm_area_struct *vma)
     // Get the AXI DMA allocation data and free the DMA buffer
     dev = axidma_dev;
     dma_alloc = vma->vm_private_data;
-    dma_free_coherent(&dev->pdev->dev, dma_alloc->size, dma_alloc->kern_addr,
-                      dma_alloc->dma_addr);
+    if (dma_alloc->cached_mapping) {
+        dma_free_attrs(&dev->pdev->dev, dma_alloc->size, dma_alloc->kern_addr,
+                       dma_alloc->dma_addr, DMA_ATTR_NON_CONSISTENT);
+    } else {
+        dma_free_coherent(&dev->pdev->dev, dma_alloc->size,
+                          dma_alloc->kern_addr, dma_alloc->dma_addr);
+    }
 
     // Remove the allocation from the list, and free the structure
     list_del(&dma_alloc->list);
@@ -276,9 +283,21 @@ static int axidma_mmap(struct file *file, struct vm_area_struct *vma)
     // Configure the DMA device
     of_dma_configure(dev->device, NULL);
 
-    // Allocate the requested region a contiguous and uncached for DMA
-    dma_alloc->kern_addr = dma_alloc_coherent(&dev->pdev->dev, dma_alloc->size,
-                                              &dma_alloc->dma_addr, GFP_KERNEL);
+    /* Allocate the requested region contiguous in CMA. When cached buffers
+     * are requested, use non-coherent mappings and manage cache maintenance
+     * explicitly to speed up CPU-side copies (e.g., writing to storage). */
+    if (dev->cached_buffers) {
+        dma_alloc->kern_addr = dma_alloc_attrs(&dev->pdev->dev,
+                                               dma_alloc->size,
+                                               &dma_alloc->dma_addr,
+                                               GFP_KERNEL,
+                                               DMA_ATTR_NON_CONSISTENT);
+    } else {
+        dma_alloc->kern_addr = dma_alloc_coherent(&dev->pdev->dev,
+                                                  dma_alloc->size,
+                                                  &dma_alloc->dma_addr,
+                                                  GFP_KERNEL);
+    }
     if (dma_alloc->kern_addr == NULL) {
         axidma_err("Unable to allocate contiguous DMA memory region of size "
                    "%zu.\n", dma_alloc->size);
@@ -289,8 +308,14 @@ static int axidma_mmap(struct file *file, struct vm_area_struct *vma)
     }
 
     // Map the region into userspace
-    rc = dma_mmap_coherent(&dev->pdev->dev, vma, dma_alloc->kern_addr,
-                           dma_alloc->dma_addr, dma_alloc->size);
+    if (dev->cached_buffers) {
+        rc = dma_mmap_attrs(&dev->pdev->dev, vma, dma_alloc->kern_addr,
+                            dma_alloc->dma_addr, dma_alloc->size,
+                            DMA_ATTR_NON_CONSISTENT);
+    } else {
+        rc = dma_mmap_coherent(&dev->pdev->dev, vma, dma_alloc->kern_addr,
+                               dma_alloc->dma_addr, dma_alloc->size);
+    }
     if (rc < 0) {
         axidma_err("Unable to remap address %p to userspace address %p, size "
                    "%zu.\n", dma_alloc->kern_addr, dma_alloc->user_addr,
@@ -308,13 +333,20 @@ static int axidma_mmap(struct file *file, struct vm_area_struct *vma)
      * referring to the DMA buffer. */
     vma->vm_flags |= VM_DONTCOPY;
 
+    dma_alloc->cached_mapping = dev->cached_buffers;
+
     // Add the allocation to the driver's list of DMA buffers
     list_add(&dma_alloc->list, &dev->dmabuf_list);
     return 0;
 
 free_dma_region:
-    dma_free_coherent(&dev->pdev->dev, dma_alloc->size, dma_alloc->kern_addr,
-                      dma_alloc->dma_addr);
+    if (dev->cached_buffers) {
+        dma_free_attrs(&dev->pdev->dev, dma_alloc->size, dma_alloc->kern_addr,
+                       dma_alloc->dma_addr, DMA_ATTR_NON_CONSISTENT);
+    } else {
+        dma_free_coherent(&dev->pdev->dev, dma_alloc->size,
+                          dma_alloc->kern_addr, dma_alloc->dma_addr);
+    }
 free_vma_data:
     kfree(dma_alloc);
 ret:

--- a/driver/axidma_dma.c
+++ b/driver/axidma_dma.c
@@ -12,6 +12,7 @@
 // Kernel dependencies
 #include <linux/delay.h>            // Milliseconds to jiffies converstion
 #include <linux/wait.h>             // Completion related functions
+#include <linux/dma-mapping.h>      // DMA cache maintenance helpers
 
 /* <linux/signal.h> was moved to <linux/sched/signal.h> in the 4.11 kernel */
 #include <linux/version.h>
@@ -54,6 +55,7 @@ struct axidma_transfer {
     bool wait;                      // Indicates if we should wait
     dma_cookie_t cookie;            // The DMA cookie for the transfer
     struct completion comp;         // A completion to use for waiting
+    struct axidma_device *dev;      // Parent device for sync helpers
     enum axidma_dir dir;            // The direction of the transfer
     enum axidma_type type;          // The type of the transfer (VDMA/DMA)
     int channel_id;                 // The ID of the channel
@@ -70,6 +72,11 @@ struct axidma_transfer {
 // The data to pass to the DMA transfer completion callback function
 struct axidma_cb_data {
     int channel_id;                 // The id of the channel used
+    struct scatterlist *sg_list;    // Buffers involved in the transfer
+    enum dma_data_direction dma_dir;// Direction for cache maintenance
+    int sg_len;                     // Number of scatter-gather entries
+    struct device *dma_dev;         // Device to use for syncing
+    bool cache_sync;                // Whether cache maintenance is required
     int notify_signal;              // For async, signal to send
     struct task_struct *process;    // The process to send the signal to
     struct completion *comp;        // For sync, the notification to kernel
@@ -96,6 +103,40 @@ static enum dma_transfer_direction axidma_to_dma_dir(enum axidma_dir dma_dir)
 {
     BUG_ON(dma_dir != AXIDMA_WRITE && dma_dir != AXIDMA_READ);
     return (dma_dir == AXIDMA_WRITE) ? DMA_MEM_TO_DEV : DMA_DEV_TO_MEM;
+}
+
+static void axidma_sync_sg_for_device(struct axidma_device *dev,
+                                      struct scatterlist *sg_list, int sg_len,
+                                      enum dma_data_direction dir)
+{
+    int i;
+
+    if (!dev->cached_buffers) {
+        return;
+    }
+
+    for (i = 0; i < sg_len; i++)
+    {
+        dma_sync_single_for_device(&dev->pdev->dev, sg_dma_address(&sg_list[i]),
+                                   sg_dma_len(&sg_list[i]), dir);
+    }
+}
+
+static void axidma_sync_sg_for_cpu(struct axidma_cb_data *cb_data)
+{
+    int i;
+
+    if (!cb_data->cache_sync) {
+        return;
+    }
+
+    for (i = 0; i < cb_data->sg_len; i++)
+    {
+        dma_sync_single_for_cpu(cb_data->dma_dev,
+                                sg_dma_address(&cb_data->sg_list[i]),
+                                sg_dma_len(&cb_data->sg_list[i]),
+                                cb_data->dma_dir);
+    }
 }
 
 /*----------------------------------------------------------------------------
@@ -148,6 +189,7 @@ static void axidma_dma_callback(void *data)
     /* For synchronous transfers, notify the kernel thread waiting. For
      * asynchronous transfers, send a signal to userspace if requested. */
     cb_data = data;
+    axidma_sync_sg_for_cpu(cb_data);
     if (cb_data->comp != NULL) {
         complete(cb_data->comp);
     } else if (VALID_NOTIFY_SIGNAL(cb_data->notify_signal)) {
@@ -207,6 +249,7 @@ static int axidma_prep_transfer(struct axidma_chan *axidma_chan,
 
     /* For VDMA transfers, we configure the channel, then prepare an interlaved
      * transfer. For DMA, we simply prepare a slave scatter-gather transfer. */
+    axidma_sync_sg_for_device(dma_tfr->dev, sg_list, sg_len, dma_dir);
     dma_flags = DMA_CTRL_ACK | DMA_PREP_INTERRUPT;
     if (dma_tfr->type == AXIDMA_DMA) {
         dma_txnd = dmaengine_prep_slave_sg(chan, sg_list, sg_len, dma_dir,
@@ -241,6 +284,12 @@ static int axidma_prep_transfer(struct axidma_chan *axidma_chan,
     /* If we're going to wait for this channel, initialize the completion for
      * the channel, and setup the callback to complete it. */
     cb_data->channel_id = dma_tfr->channel_id;
+    cb_data->sg_list = sg_list;
+    cb_data->sg_len = sg_len;
+    cb_data->dma_dir = dma_dir;
+    cb_data->dma_dev = &dma_tfr->dev->pdev->dev;
+    cb_data->cache_sync = dma_tfr->dev->cached_buffers &&
+                          dma_dir == DMA_DEV_TO_MEM;
     if (dma_tfr->wait) {
         cb_data->comp = dma_comp;
         cb_data->notify_signal = -1;
@@ -379,6 +428,7 @@ int axidma_read_transfer(struct axidma_device *dev,
     // Setup receive transfer structure for DMA
     rx_tfr.sg_list = &sg_list;
     rx_tfr.sg_len = 1;
+    rx_tfr.dev = dev;
     rx_tfr.dir = rx_chan->dir;
     rx_tfr.type = rx_chan->type;
     rx_tfr.wait = trans->wait;
@@ -429,6 +479,7 @@ int axidma_write_transfer(struct axidma_device *dev,
     // Setup transmit transfer structure for DMA
     tx_tfr.sg_list = &sg_list;
     tx_tfr.sg_len = 1;
+    tx_tfr.dev = dev;
     tx_tfr.dir = tx_chan->dir;
     tx_tfr.type = tx_chan->type;
     tx_tfr.wait = trans->wait;
@@ -494,6 +545,7 @@ int axidma_rw_transfer(struct axidma_device *dev,
     // Setup receive and trasmit transfer structures for DMA
     tx_tfr.sg_list = &tx_sg_list,
     tx_tfr.sg_len = 1,
+    tx_tfr.dev = dev,
     tx_tfr.dir = tx_chan->dir,
     tx_tfr.type = tx_chan->type,
     tx_tfr.wait = false,
@@ -509,6 +561,7 @@ int axidma_rw_transfer(struct axidma_device *dev,
 
     rx_tfr.sg_list = &rx_sg_list,
     rx_tfr.sg_len = 1,
+    rx_tfr.dev = dev,
     rx_tfr.dir = rx_chan->dir,
     rx_tfr.type = rx_chan->type,
     rx_tfr.wait = trans->wait,
@@ -557,6 +610,7 @@ int axidma_video_transfer(struct axidma_device *dev,
     // Setup transmit transfer structure for DMA
     struct axidma_transfer transfer = {
         .sg_len = trans->num_frame_buffers,
+        .dev = dev,
         .dir = dir,
         .type = AXIDMA_VDMA,
         .wait = false,


### PR DESCRIPTION
## Summary
- add a cached_buffers module parameter to request cacheable CMA allocations for axidma mmap buffers
- add cache maintenance hooks around DMA transfers so cached buffers stay coherent
- document the new option in CODE_OVERVIEW

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e63de2db0833093a233b853a1f78a)